### PR TITLE
v0.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "nbsphinx" %}
-{% set version = "0.2.18" %}
+{% set version = "0.3.1" %}
+{% set md5 = "7deb7951b423689d4f89d7714005c17d" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7c31c9185134b4ce8c347220a9720e5dc59a20584ce993c7c9aa25401b3a1f44
+  md5: {{ md5 }}
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "nbsphinx" %}
 {% set version = "0.3.1" %}
-{% set md5 = "7deb7951b423689d4f89d7714005c17d" %}
+{% set sha256 = "e350c96e92ead8ee87c1a2e115bcfe1708f039a0bb48754cce94451b49ad631b" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: {{ md5 }}
+  sha256: {{ sha256 }}
 
 build:
   number: 0


### PR DESCRIPTION
Also switched to using md5 (which you can get from pypi).

The 0.3.1 release should fix LaTeX build problems when using nbsphinx with sphinx 1.6.6 or later (https://github.com/spatialaudio/nbsphinx/pull/159).